### PR TITLE
refactor: Replace server upload with local storage for USB transfer

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,4 @@ dependencies {
     implementation libs.camera.lifecycle
     implementation libs.camera.video
     implementation libs.camera.view
-
-    // OkHttp dependency
-    implementation libs.okhttp
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.INTERNET" />
 
     <uses-feature android:name="android.hardware.camera.any" />
 

--- a/app/src/main/java/com/example/cameratoserver/MainActivity.java
+++ b/app/src/main/java/com/example/cameratoserver/MainActivity.java
@@ -33,21 +33,12 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.MediaType;
-import okhttp3.MultipartBody;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
 
 public class MainActivity extends AppCompatActivity {
 
     private static final String TAG = "MainActivity";
     private static final int REQUEST_CODE_PERMISSIONS = 10;
     private static final String[] REQUIRED_PERMISSIONS = new String[]{Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO};
-    private final String UPLOAD_URL = "http://example.com/upload"; // TODO: サーバーのURLに書き換えてください
 
     private PreviewView previewView;
     private Button startButton;
@@ -155,11 +146,9 @@ public class MainActivity extends AppCompatActivity {
                             Toast.makeText(MainActivity.this, "Recording started", Toast.LENGTH_SHORT).show();
                         } else if (videoRecordEvent instanceof VideoRecordEvent.Finalize) {
                             if (!((VideoRecordEvent.Finalize) videoRecordEvent).hasError()) {
-                                String msg = "Video capture succeeded: " + ((VideoRecordEvent.Finalize) videoRecordEvent).getOutputResults().getOutputUri();
-                                Toast.makeText(getBaseContext(), msg, Toast.LENGTH_SHORT).show();
-                                Log.d(TAG, msg);
-                                File file = new File(PathUtil.getPath(MainActivity.this, ((VideoRecordEvent.Finalize) videoRecordEvent).getOutputResults().getOutputUri()));
-                                uploadVideo(file);
+                                String msg = "Video saved to Movies/CameraToServer. Connect to PC via USB to transfer.";
+                                Toast.makeText(getBaseContext(), msg, Toast.LENGTH_LONG).show();
+                                Log.d(TAG, "Video capture succeeded: " + ((VideoRecordEvent.Finalize) videoRecordEvent).getOutputResults().getOutputUri());
                             } else {
                                 if (activeRecording != null) {
                                     activeRecording.close();
@@ -173,41 +162,6 @@ public class MainActivity extends AppCompatActivity {
                         }
                     }
                 });
-    }
-
-
-    private void uploadVideo(File videoFile) {
-        OkHttpClient client = new OkHttpClient();
-
-        RequestBody requestBody = new MultipartBody.Builder()
-                .setType(MultipartBody.FORM)
-                .addFormDataPart("video", videoFile.getName(),
-                        RequestBody.create(videoFile, MediaType.parse("video/mp4")))
-                .build();
-
-        Request request = new Request.Builder()
-                .url(UPLOAD_URL)
-                .post(requestBody)
-                .build();
-
-        client.newCall(request).enqueue(new Callback() {
-            @Override
-            public void onFailure(@NonNull Call call, @NonNull IOException e) {
-                Log.e(TAG, "Upload failed", e);
-                runOnUiThread(() -> Toast.makeText(MainActivity.this, "Upload failed: " + e.getMessage(), Toast.LENGTH_SHORT).show());
-            }
-
-            @Override
-            public void onResponse(@NonNull Call call, @NonNull Response response) throws IOException {
-                if (response.isSuccessful()) {
-                    Log.d(TAG, "Upload successful");
-                    runOnUiThread(() -> Toast.makeText(MainActivity.this, "Upload successful", Toast.LENGTH_SHORT).show());
-                } else {
-                    Log.e(TAG, "Upload failed: " + response.body().string());
-                    runOnUiThread(() -> Toast.makeText(MainActivity.this, "Upload failed: " + response.code(), Toast.LENGTH_SHORT).show());
-                }
-            }
-        });
     }
 
     private void updateUI(boolean isRecording) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ espressoCore = "3.6.1"
 appcompat = "1.7.1"
 material = "1.12.0"
 camerax = "1.3.1"
-okhttp = "4.12.0"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -19,7 +18,6 @@ camera-camera2 = { group = "androidx.camera", name = "camera-camera2", version.r
 camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camerax" }
 camera-video = { group = "androidx.camera", name = "camera-video", version.ref = "camerax" }
 camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "camerax" }
-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 
 
 [plugins]


### PR DESCRIPTION
This commit refactors the application to save recorded videos to the device's local storage instead of uploading them to a server. This allows you to transfer the video to a PC via a USB connection.

The following changes were made:
- Removed the OkHttp dependency and the `INTERNET` permission.
- Removed the video upload logic from `MainActivity`.
- Added a `Toast` notification to inform you where the video file is saved, making it easy to find and transfer.